### PR TITLE
SDB Writing

### DIFF
--- a/FauFau/Util/Common.cs
+++ b/FauFau/Util/Common.cs
@@ -137,6 +137,7 @@ namespace FauFau.Util
                 destination.Write.ByteArray(inflated.ToArray());
             }
         }
+
         public static void Deflate(BinaryStream source, BinaryStream destination, CompressionLevel level = CompressionLevel.Default, int start = -1, int length = -1)
         {
             if (start > 0) { source.ByteOffset = start; }
@@ -337,6 +338,28 @@ namespace FauFau.Util
             }
 
             return true;
+        }
+
+        public static int FindClosestLargerNumber(int n, int m)
+        {
+            // find the quotient
+            int q = n / m;
+        
+            // 1st possible closest number
+            int n1 = m * q;
+            
+            if (n1 >= n) {
+                return n1;
+            }
+
+            // 2nd possible closest number
+            int n2 = (n * m) > 0 ? (m * (q + 1)) : (m * (q - 1));
+            
+            if (n2 >= n) {
+                return n2;
+            }
+
+            throw new NotImplementedException("waewaewaewaewae"); 
         }
         
     }

--- a/Tests/Program.cs
+++ b/Tests/Program.cs
@@ -12,13 +12,17 @@ namespace Tests
         {
             //Red5SigTests.Test1();
             
-            //GtChunksTests.TestLoad();
+            //GtChunksTests.TestLoa RowInfo rowInfo = rowInfos[i];d();
 
             //AuthTests.VerifyBench();
             
             //AuthTests.SecretBench();
             
-            AuthTests.UserIdBench();
+            //AuthTests.UserIdBench();
+            
+            //SDBTests.TestRead();
+            //SDBTests.TestWriteCustom();
+            //SDBTests.TestReadCustom();
         }
     }
 }

--- a/Tests/SDBTests.cs
+++ b/Tests/SDBTests.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.IO;
+using FauFau.Formats;
+using static FauFau.Formats.StaticDB;
+
+namespace Tests
+{
+    public class SDBTests
+    {
+        public static string sdbPathRead = @"X:\Firefall\system\db\clientdb.sd2";
+        public static string sdbPathWrite = @"X:\Firefall\system\db\clientdb.write.sd2";
+
+        public static void TestRead()
+        {
+            Console.WriteLine("SDBTests.TestRead: Reading SDB: " + sdbPathRead);
+            StaticDB sdb = new StaticDB();
+            sdb.Read(sdbPathRead);
+            Console.WriteLine("Patch: " + sdb.Patch);
+            Console.WriteLine("Flags: " + sdb.Flags);
+            Console.WriteLine("Created: " + sdb.Timestamp.ToString() + " UTC");
+            Console.WriteLine();
+        }
+
+        public static void TestWriteCustom()
+        {
+            // Read from a real SDB to get the base data
+            Console.WriteLine("SDBTests.TestWriteCustom: Reading SDB: " + sdbPathRead);
+            StaticDB sdb = new StaticDB();
+            sdb.Read(sdbPathRead);
+
+            // Proof of concept: Modify data
+            if (true) {
+                Row duplicateRow(Table table, Row existing) {
+                    Row row = new Row(table.Columns.Count);
+                    for (int x = 0; x < table.Columns.Count; x++) {
+                        Column column = table.Columns[x];
+                        if (IsDataType(column.Type)) {
+                            row.Fields.Add( existing.Fields[x] );
+                        }
+                        else {
+                            row.Fields.Add( existing.Fields[x] );
+                        }
+                    }
+                    return row;
+                }
+
+                // Add ZoneRecord
+                if (true) {
+                    Table table = sdb.GetTableByName("dbzonemetadata::ZoneRecord");
+                    Row existing = table[0];
+                    Row row = duplicateRow(table, existing);
+                    table.Rows.Insert(0, row);
+                    row[table.GetColumnIndexByName("localized_name_id")] = (uint) 0;
+                    row[table.GetColumnIndexByName("localized_main_title_id")] = (uint) 0;
+                    row[table.GetColumnIndexByName("localized_minor_title_id")] = (uint) 0;
+                    row[table.GetColumnIndexByName("localized_sub_title_id")] = (uint) 0;
+                    row[table.GetColumnIndexByName("name")] = (string) "Net Slum\0";
+                    row[table.GetColumnIndexByName("main_title")] = (string) "Net Slum\0";
+                    row[table.GetColumnIndexByName("minor_title")] = (string) "FauFau\0";
+                    row[table.GetColumnIndexByName("sub_title")] = (string) "In the database, database\0";
+                    row[table.GetColumnIndexByName("id")] = (uint) 11;
+                    row[table.GetColumnIndexByName("level_band")] = (ushort) 0;
+                    row[table.GetColumnIndexByName("zoneType")] = (byte) 0;
+                    row[table.GetColumnIndexByName("prevent_sub_zone_spawns")] = (byte) 0;
+                }
+                
+                // Add ZoneChunkLinker
+                if (true) {
+                    Table table = sdb.GetTableByName("dbzonemetadata::ZoneChunkLinker");
+                    Row existing = table[0];
+                    Row row = duplicateRow(table, existing);
+                    table.Rows.Insert(0, row);
+                    row[table.GetColumnIndexByName("zoneid")] = (uint) 11;
+                }
+            }
+            
+            // Write
+            Console.WriteLine("SDBTests.TestWriteCustom: Writing SDB: " + sdbPathWrite);
+            sdb.Write(sdbPathWrite);
+
+            Console.WriteLine();
+        }
+
+        public static void TestReadCustom()
+        {
+            Console.WriteLine("SDBTests.TestReadCustom: Reading from write path: " + sdbPathWrite);
+            StaticDB sdb = new StaticDB();
+            sdb.Read(sdbPathWrite);
+            Console.WriteLine("SDBTests.TestReadCustom: Patch: " + sdb.Patch);
+            Console.WriteLine("SDBTests.TestReadCustom: Flags: " + sdb.Flags);
+            Console.WriteLine("SDBTests.TestReadCustom: Created: " + sdb.Timestamp.ToString() + " UTC");
+            Console.WriteLine();
+        }
+
+    }
+}


### PR DESCRIPTION
Implemented Write method of StaticDB.
This probably needs a sanity check for code quality, but the added tests work on 1962.
The written files are accepted both by SDBrowser, and the game seems to be fine with mods and additions, as long as new rows follow the expected index order of that table.
Reading and parsing the original database does not produce 100% identical output, with some difference in the keyed data section, and minor diff in the deflated output.
I did not perfectly implement the generation of the keys for the data section, see the function GenerateDataEntryKey. I verified that the alternate version produced the expected keys for two data points, but when put in use I ended up with garbled output for many values (but not all), particularly in the localization table.

